### PR TITLE
Fix: Add 'labeled' trigger to issue-to-pr workflow

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -2,7 +2,7 @@ name: Create PR from New Location Issue
 
 on:
   issues:
-    types: [opened, edited]
+    types: [opened, edited, labeled]
 
 jobs:
   create-pr:


### PR DESCRIPTION
## Summary

The issue-to-pr workflow was skipping because it only triggered on `opened` and `edited` events. Since the issue template applies the `new-location` label, we need to also trigger on `labeled`.

## Test plan

- [ ] Merge this PR
- [ ] Re-label issue #2 to trigger the workflow