### PR TITLE
Add Location: Regent University Library and Kempsville Area Library (Virginia Beach)

### DIFF
--- a/LOCATIONS.md
+++ b/LOCATIONS.md
@@ -5,4 +5,6 @@ Public bulletin boards in Hampton Roads, Virginia where you can post community n
 | City | Name | Address | Map | Notes |
 |------|------|---------|-----|-------|
 | Norfolk | Ten Top | 748 Shirley Ave, Norfolk, VA 23517 | [Map](https://maps.app.goo.gl/BBA84eUKjnMxXxVb8) | Allows fliers in the windows (Ghent area) |
+| Virginia Beach | Kempsville Area Library | 832 Kempsville Rd, Virginia Beach, VA 23464 | [Map](https://maps.app.goo.gl/gQYfn8BtAkZVJSpx7) | Enter through the front door. The librarian will post flyers on the community bulletin board as long as there is a date and location listed. |
+| Virginia Beach | Regent University Library | 1000 Regent University Dr, Virginia Beach, VA 23464 | [Map](https://maps.app.goo.gl/TwiJYZZQB5h4mrLG6) | Parking is in the rear of the building. Enter through the front door. Walk in and ring the bell for access. Guest Services will check your ID and direct you to the left, where Print Card Services is located. Staff will accept 7 flyers and post them around campus. |
 | Virginia Beach | Town Center Coldpressed | 168 Central Park Ave, Virginia Beach, VA 23462 | [Map](https://maps.app.goo.gl/QPpKZYKL4CdyJpCp8) | There is a section inside the door with flyers and notices.  It's requested to contact `joe.trask@tccp.cafe` before putting material there. |

--- a/data/locations.json
+++ b/data/locations.json
@@ -12,5 +12,19 @@
     "city": "Virginia Beach",
     "google_maps_link": "https://maps.app.goo.gl/QPpKZYKL4CdyJpCp8",
     "notes": "There is a section inside the door with flyers and notices.  It's requested to contact `joe.trask@tccp.cafe` before putting material there."
+  },
+  {
+    "name": "Regent University Library",
+    "address": "1000 Regent University Dr, Virginia Beach, VA 23464",
+    "city": "Virginia Beach",
+    "google_maps_link": "https://maps.app.goo.gl/TwiJYZZQB5h4mrLG6",
+    "notes": "Parking is in the rear of the building. Enter through the front door. Walk in and ring the bell for access. Guest Services will check your ID and direct you to the left, where Print Card Services is located. Staff will accept 7 flyers and post them around campus."
+  },
+  {
+    "name": "Kempsville Area Library",
+    "address": "832 Kempsville Rd, Virginia Beach, VA 23464",
+    "city": "Virginia Beach",
+    "google_maps_link": "https://maps.app.goo.gl/gQYfn8BtAkZVJSpx7",
+    "notes": "Enter through the front door. The librarian will post flyers on the community bulletin board as long as there is a date and location listed."
   }
 ]


### PR DESCRIPTION
Adding 2 library community boards in Virginia Beach with verified name, address, city, Google Maps link and notes.