### PR TITLE
Fix README workflow for pull requests from forks

### DIFF
--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -1,22 +1,23 @@
-name: Sync README locations table
+name: Check README locations table
 
 on:
   pull_request:
     paths:
       - 'data/locations/**'
+      - 'README.md'
+      - 'scripts/generate-readme.js'
+      - 'scripts/locations.js'
+
+permissions:
+  contents: read
 
 jobs:
-  sync:
+  check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout pull request
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -26,20 +27,9 @@ jobs:
       - name: Regenerate README locations table
         run: node scripts/generate-readme.js
 
-      - name: Check for changes
-        id: diff
+      - name: Verify README is up to date
         run: |
-          if git diff --quiet README.md; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+          if ! git diff --exit-code -- README.md; then
+            echo "::error file=README.md::The locations table is out of date. Run 'node scripts/generate-readme.js', commit README.md, and push the update."
+            exit 1
           fi
-
-      - name: Commit updated README.md
-        if: steps.diff.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit -m "Auto-regenerate README locations table from data/locations/"
-          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,11 @@ Triggers when an issue with "new-location" label is opened/edited:
 5. Creates PR linking to the issue (or force-updates the existing PR branch on issue edits)
 6. Comments on issue with PR link
 
-### README sync (`sync-readme.yml`)
-Runs on PRs that modify `data/locations/**`: regenerates the README locations table and commits it to the PR branch if it changed.
+### README check (`sync-readme.yml`)
+Runs on PRs that modify location data, README, or its generator scripts. It regenerates the locations table in a read-only checkout and fails with a remediation command if the committed README is stale. It does not push into contributor branches, so it works safely for PRs from forks.
 
 ### Validation (`validate-locations.yml`)
 Runs on PRs that modify location files, README, scripts, or tests:
 - Runs test suite (`npm test`)
 - Validates `data/locations/` and README table sync (`npm run validate`)
+


### PR DESCRIPTION
## Problem

`sync-readme.yml` checks out `${{ github.head_ref }}` from the upstream repository. For pull requests opened from a fork, that branch only exists in the contributor's fork, so `actions/checkout` retries and fails before the workflow reaches the README generator. This caused the failures on #179 and #180.

Even if checkout targeted the fork, the upstream `GITHUB_TOKEN` should not be used to push changes into an untrusted contributor branch.

## Fix

- check out GitHub's normal pull-request merge ref instead of assuming the head branch is in the upstream repository
- regenerate README and verify it has no diff
- report a clear remediation command if README is stale
- reduce workflow permissions to read-only
- include generator scripts in the path trigger
- update `actions/checkout` to v5

The issue-to-PR automation already generates README before opening its PR, so automated location PRs should pass this check. External contributors get an actionable validation failure instead of a workflow attempting to write into their fork.

## Evidence

- #180 validation workflow passed, confirming the location data and generated README were valid
- failed run `31595005636` stopped during checkout while fetching the fork-only branch from `RevolutionVA/Hampton-Roads-Community-Board-Map`
- #179 failed at the same checkout step for another `shedquartersbot` branch